### PR TITLE
Increase number of supported devices to 16.

### DIFF
--- a/include/libxstream_config.h
+++ b/include/libxstream_config.h
@@ -97,7 +97,7 @@
 #define LIBXSTREAM_MAX_ALIGN (2 * 1024 * 1024)
 
 /** Maximum number of devices (POT). */
-#define LIBXSTREAM_MAX_NDEVICES 4
+#define LIBXSTREAM_MAX_NDEVICES 16
 
 /** Maximum number of streams per device (POT). */
 #define LIBXSTREAM_MAX_NSTREAMS 32


### PR DESCRIPTION
This change increases the number of supported offload devices to
16 to support large machines.  This is in response to a complain
that was filed against pyMIC for a machine with 8 coprocessors.
