### PR TITLE
CMake: Install OpenCL SMM support files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(LIBXS_GIT_TAG "main")
 
 find_package(libxs CONFIG QUIET)
 if(NOT TARGET libxs::libxs)
+  message(STATUS "CMake-built libxs NOT found; finding Makefile-based LIBXS tree...")
   set(LIBXSROOT "${PROJECT_SOURCE_DIR}/../libxs" CACHE PATH
     "Root of a Makefile-built LIBXS tree (sibling directory by default)")
   find_library(LIBXS_LIBRARY NAMES xs HINTS "${LIBXSROOT}/lib")
@@ -25,6 +26,7 @@ if(NOT TARGET libxs::libxs)
   endif()
 endif()
 if(NOT TARGET libxs::libxs)
+  message(STATUS "Cannot find libxs locally; downloading through FetchContent...")
   include(FetchContent)
   FetchContent_Declare(libxs
     GIT_REPOSITORY ${LIBXS_GIT_REPOSITORY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/scripts/libxstreamConfig.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/libxstreamConfig.cmake"
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libxstream
-  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR)
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_DATADIR)
 
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/libxstreamConfigVersion.cmake"
@@ -192,6 +192,21 @@ if(NOT LIBXSTREAM_HEADER_ONLY)
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
   )
 endif()
+
+install(FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/scripts/tool_opencl.sh"
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/libxstream/scripts)
+
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/samples/smm/"
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/libxstream/samples/smm
+  FILES_MATCHING
+    PATTERN "*.c"
+    PATTERN "*.h"
+    PATTERN "*.cl"
+    PATTERN "*.csv"
+    PATTERN "*.bin"
+    PATTERN "*.py"
+    PATTERN "*.sh")
 
 install(EXPORT libxstreamTargets
   FILE libxstreamTargets.cmake

--- a/scripts/libxstreamConfig.cmake.in
+++ b/scripts/libxstreamConfig.cmake.in
@@ -16,4 +16,11 @@ set_and_check(LIBXSTREAM_TARGETS_FILE
   "${CMAKE_CURRENT_LIST_DIR}/libxstreamTargets.cmake")
 include("${LIBXSTREAM_TARGETS_FILE}")
 
+set_and_check(LIBXSTREAM_OPENCL_SCRIPT
+  "@PACKAGE_CMAKE_INSTALL_DATADIR@/libxstream/scripts/tool_opencl.sh")
+set_and_check(LIBXSTREAM_SMM_DIR
+  "@PACKAGE_CMAKE_INSTALL_DATADIR@/libxstream/samples/smm")
+set_and_check(LIBXSTREAM_SMM_ACC_SOURCE
+  "@PACKAGE_CMAKE_INSTALL_DATADIR@/libxstream/samples/smm/smm_acc.c")
+
 check_required_components(libxstream)


### PR DESCRIPTION
Install the OpenCL helper script and SMM sample artifacts, and expose their install-tree paths through `libxstreamConfig.cmake` for downstream CMake packages.

This will hopefully resolve [DBCSR OpenCL testing failre](https://github.com/cp2k/dbcsr/actions/runs/27147877790/job/80132808685?pr=1018).