### PR TITLE
fix: add integer overflow check in ozaki_bench.c

### DIFF
--- a/samples/ozaki/ozaki_bench.c
+++ b/samples/ozaki/ozaki_bench.c
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
   libxstream_stream_t* stream = NULL;
   libxs_matdiff_t diff;
   libxs_timer_tick_t t0, t1;
-  size_t elem_size = 0;
+  size_t elem_size = 0, c_size = 0;
   int result = EXIT_SUCCESS;
   int initialized = 0;
 
@@ -136,16 +136,21 @@ int main(int argc, char* argv[])
   if (EXIT_SUCCESS == result) {
     const int a_rows = (0 == ta ? M : K), a_cols = (0 == ta ? K : M);
     const int b_rows = (0 == tb ? K : N), b_cols = (0 == tb ? N : K);
-    if ((size_t)lda > SIZE_MAX / (size_t)a_cols / sizeof(double)
-      || (size_t)ldb > SIZE_MAX / (size_t)b_cols / sizeof(double)
-      || (size_t)ldc > SIZE_MAX / (size_t)N / sizeof(double)) {
+    if ((size_t)lda * a_cols > SIZE_MAX / elem_size
+      || (size_t)ldb * b_cols > SIZE_MAX / elem_size
+      || (size_t)ldc * N > SIZE_MAX / elem_size) {
       fprintf(stderr, "ERROR: matrix dimensions too large (overflow)\n");
       result = EXIT_FAILURE;
     }
-    if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&a, (size_t)lda * a_cols * elem_size, stream);
-    if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&b, (size_t)ldb * b_cols * elem_size, stream);
-    if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&c_oz, (size_t)ldc * N * elem_size, stream);
-    if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&c_ref, (size_t)ldc * N * elem_size, stream);
+    if (EXIT_SUCCESS == result) {
+      const size_t a_size = (size_t)lda * a_cols * elem_size;
+      const size_t b_size = (size_t)ldb * b_cols * elem_size;
+      c_size = (size_t)ldc * N * elem_size;
+      result = libxstream_mem_host_allocate((void**)&a, a_size, stream);
+      if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&b, b_size, stream);
+      if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&c_oz, c_size, stream);
+      if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&c_ref, c_size, stream);
+    }
     if (EXIT_SUCCESS != result) {
       fprintf(stderr, "ERROR: out of memory\n");
       result = EXIT_FAILURE;
@@ -161,7 +166,7 @@ int main(int argc, char* argv[])
         LIBXS_MATRNG(int, float, 0, b, b_rows, b_cols, ldb, 1.0);
         LIBXS_MATRNG(int, float, 0, c_oz, M, N, ldc, 1.0);
       }
-      memcpy(c_ref, c_oz, (size_t)ldc * N * elem_size);
+      memcpy(c_ref, c_oz, c_size);
     }
   }
 
@@ -172,7 +177,7 @@ int main(int argc, char* argv[])
     result = ozaki_gemm(&ctx, stream, transa, transb, M, N, K, alpha, a, lda, b, ldb, beta, c_oz, ldc, NULL, 0, 0);
     libxstream_stream_sync(stream);
     /* restore C for the timed run (beta may be non-zero) */
-    if (EXIT_SUCCESS == result) memcpy(c_oz, c_ref, (size_t)ldc * N * elem_size);
+    if (EXIT_SUCCESS == result) memcpy(c_oz, c_ref, c_size);
     t0 = libxs_timer_tick();
     for (i = 0; i < nrepeat; ++i) {
       result = ozaki_gemm(&ctx, stream, transa, transb, M, N, K, alpha, a, lda, b, ldb, beta, c_oz, ldc, NULL, 0, 0);
@@ -191,7 +196,7 @@ int main(int argc, char* argv[])
     int i;
     /* save original C (still in c_ref) into c_oz; the Ozaki result will
      * be recomputed below for comparison after BLAS timing is done */
-    memcpy(c_oz, c_ref, (size_t)ldc * N * elem_size);
+    memcpy(c_oz, c_ref, c_size);
     t0 = libxs_timer_tick();
     for (i = 0; i < nrepeat; ++i) {
       if (ctx.use_double) {
@@ -202,7 +207,7 @@ int main(int argc, char* argv[])
         SGEMM(&transa, &transb, &M, &N, &K, &falpha, (const float*)a, &lda, (const float*)b, &ldb, &fbeta, (float*)c_ref, &ldc);
       }
       /* restore C before next iteration so beta does not accumulate */
-      if (i < nrepeat - 1) memcpy(c_ref, c_oz, (size_t)ldc * N * elem_size);
+      if (i < nrepeat - 1) memcpy(c_ref, c_oz, c_size);
     }
     t1 = libxs_timer_tick();
     printf("BLAS  GEMM: %.1f ms\n", 1E3 * libxs_timer_duration(t0, t1) / nrepeat);

--- a/samples/ozaki/ozaki_bench.c
+++ b/samples/ozaki/ozaki_bench.c
@@ -136,7 +136,13 @@ int main(int argc, char* argv[])
   if (EXIT_SUCCESS == result) {
     const int a_rows = (0 == ta ? M : K), a_cols = (0 == ta ? K : M);
     const int b_rows = (0 == tb ? K : N), b_cols = (0 == tb ? N : K);
-    result = libxstream_mem_host_allocate((void**)&a, (size_t)lda * a_cols * elem_size, stream);
+    if ((size_t)lda > SIZE_MAX / (size_t)a_cols / sizeof(double)
+      || (size_t)ldb > SIZE_MAX / (size_t)b_cols / sizeof(double)
+      || (size_t)ldc > SIZE_MAX / (size_t)N / sizeof(double)) {
+      fprintf(stderr, "ERROR: matrix dimensions too large (overflow)\n");
+      result = EXIT_FAILURE;
+    }
+    if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&a, (size_t)lda * a_cols * elem_size, stream);
     if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&b, (size_t)ldb * b_cols * elem_size, stream);
     if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&c_oz, (size_t)ldc * N * elem_size, stream);
     if (EXIT_SUCCESS == result) result = libxstream_mem_host_allocate((void**)&c_ref, (size_t)ldc * N * elem_size, stream);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `samples/ozaki/ozaki_bench.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `samples/ozaki/ozaki_bench.c:148` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-190 |

**Description**: The matrix dimensions M, N, K, lda, ldb, ldc are taken from command-line arguments via atoi(). The size calculation `(size_t)ldc * N * elem_size` used in memory allocation and memcpy calls can overflow if large values are provided. While basic sanity checks exist, they do not prevent integer overflow in the multiplication, potentially leading to allocation of smaller buffers than expected and subsequent out-of-bounds writes.

## Evidence

**Exploitation scenario**: Run the benchmark with crafted arguments: `./ozaki_bench 65536 65536 65536` — on systems where size_t is 32-bit or where intermediate multiplication overflows, allocated buffers will be smaller than.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `samples/ozaki/ozaki_bench.c`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `samples/ozaki/ozaki_bench.c:164`, `samples/ozaki/ozaki_bench.c:175`, `samples/ozaki/ozaki_bench.c:194`, `samples/ozaki/ozaki_bench.c:205`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

## Security Invariant
> **Property**: The security boundary is maintained under adversarial input

<details>
<summary>Regression test</summary>

```c
#include <check.h>
#include <stdlib.h>
#include <stdio.h>
#include <string.h>
#include <unistd.h>
#include <sys/wait.h>

START_TEST(test_integer_overflow_protection)
{
    // Invariant: Memory allocation size calculations must not overflow
    // and cause undersized buffer allocations
    const char *payloads[] = {
        // Exploit case: values causing overflow in ldc * N * elem_size
        "ozaki_bench 1000 1000 1000 1000000 1000000 1000000",
        // Boundary case: maximum values before overflow (assuming 64-bit size_t)
        "ozaki_bench 1 1 1 4294967295 1 1",
        // Valid input
        "ozaki_bench 100 100 100 100 100 100"
    };
    int num_payloads = sizeof(payloads) / sizeof(payloads[0]);

    for (int i = 0; i < num_payloads; i++) {
        pid_t pid = fork();
        if (pid == 0) {
            // Child process: execute the actual program
            char *args[] = {
                "sh", "-c", NULL
            };
            char command[512];
            snprintf(command, sizeof(command), "./%s", payloads[i]);
            args[2] = command;
            
            // Execute through shell to handle the full command line
            execlp("sh", "sh", "-c", command, NULL);
            _exit(EXIT_FAILURE); // If execlp fails
        } else if (pid > 0) {
            // Parent process: wait for child
            int status;
            waitpid(pid, &status, 0);
            
            // Property: Program must not crash with out-of-bounds writes
            // We check it either exits cleanly or with controlled error
            ck_assert_msg(!WIFSIGNALED(status) || WTERMSIG(status) != SIGSEGV,
                         "Program crashed with segmentation fault on input: %s",
                         payloads[i]);
        }
    }
}
END_TEST

Suite *security_suite(void)
{
    Suite *s;
    TCase *tc_core;

    s = suite_create("Security");
    tc_core = tcase_create("Core");

    tcase_add_test(tc_core, test_integer_overflow_protection);
    suite_add_tcase(s, tc_core);

    return s;
}

int main(void)
{
    int number_failed;
    Suite *s;
    SRunner *sr;

    s = security_suite();
    sr = srunner_create(s);

    srunner_run_all(sr, CK_NORMAL);
    number_failed = srunner_ntests_failed(sr);
    srunner_free(sr);

    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
}
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
